### PR TITLE
Correct types in DocBlocks.

### DIFF
--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -899,11 +899,11 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 	/**
 	 * Update terms for the post for a given taxonomy
-	 * 
+	 *
 	 * @param    array      $terms   array of terms (name or ids)
 	 * @param    string     $tax     the name of the tax
 	 * @param    boolean    $append  if true, will append the terms, false will replace existing terms
-	 * 
+	 *
 	 * @return bool
 	 * @since    3.8.0
 	 * @version  3.8.0

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -43,7 +43,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 	/**
 	 * Instance of WP_Post
-	 * @var obj
+	 * @var WP_Post
 	 * @since 3.0.0
 	 */
 	protected $post;
@@ -69,8 +69,8 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * Constructor
 	 * Setup ID and related post property
 	 *
-	 * @param     int|obj    $model   WP post id, instance of an extending class, instance of WP_Post
-	 * @param     array     $args    args to create the post, only applies when $model is 'new'
+	 * @param     int|LLMS_Post_Model|WP_Post $model WP post id, instance of an extending class, instance of WP_Post
+	 * @param     array                       $args  args to create the post, only applies when $model is 'new'
 	 * @return    void
 	 * @since     3.0.0
 	 * @version   3.13.0
@@ -283,7 +283,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	/**
 	 * Wrapper for the $this->translate() that echos the result rather than returning it
 	 * @param    string     $key  key to retrieve
-	 * @return   string
+	 * @return   void
 	 * @since    3.0.0
 	 * @version  3.0.0
 	 */
@@ -481,7 +481,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 	/**
 	 * Retrieve the Post's post type data object
-	 * @return obj
+	 * @return WP_Post_Type|null
 	 * @since  3.0.0
 	 */
 	public function get_post_type_data() {
@@ -707,7 +707,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * If a child class adds any properties which should not be settable
 	 * the class should override this property and add their custom
 	 * properties to the array
-	 * @var array
+	 * @return array
 	 * @since 3.0.0
 	 */
 	protected function get_unsettable_properties() {
@@ -899,9 +899,12 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 	/**
 	 * Update terms for the post for a given taxonomy
+	 * 
 	 * @param    array      $terms   array of terms (name or ids)
 	 * @param    string     $tax     the name of the tax
 	 * @param    boolean    $append  if true, will append the terms, false will replace existing terms
+	 * 
+	 * @return bool
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */


### PR DESCRIPTION
## Description
```
LLMS_Post_Model->post
LLMS_Post_Model->__constructor()
LLMS_Post_Model->_e()
LLMS_Post_Model->get_post_type_data()
LLMS_Post_Model->get_unsettable_properties()
LLMS_Post_Model->set_terms()
```
## How has this been tested?
No code was changed. Only PHP DocBlocks have been changed until PhpStorm stopped warning about incorrect types.

## Types of changes
+ `obj` changed to one or more classes.
+ `string` changed to `void` when a method echos a string instead of returning it
+ changed spaces for formatting

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script phpunit` -->
- [X] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
